### PR TITLE
Re-fix broken lapis minion sub-IDs

### DIFF
--- a/items/LAPIS_GENERATOR_1.json
+++ b/items/LAPIS_GENERATOR_1.json
@@ -14,15 +14,15 @@
     "§7Max Storage: §e64"
   ],
   "recipe": {
-    "A1": "INK_SACK:4:32",
-    "A2": "INK_SACK:4:32",
-    "A3": "INK_SACK:4:32",
-    "B1": "INK_SACK:4:32",
+    "A1": "INK_SACK-4:32",
+    "A2": "INK_SACK-4:32",
+    "A3": "INK_SACK-4:32",
+    "B1": "INK_SACK-4:32",
     "B2": "WOOD_PICKAXE:1",
-    "B3": "INK_SACK:4:32",
-    "C1": "INK_SACK:4:32",
-    "C2": "INK_SACK:4:32",
-    "C3": "INK_SACK:4:32"
+    "B3": "INK_SACK-4:32",
+    "C1": "INK_SACK-4:32",
+    "C2": "INK_SACK-4:32",
+    "C3": "INK_SACK-4:32"
   },
   "internalname": "LAPIS_GENERATOR_1",
   "clickcommand": "viewrecipe",


### PR DESCRIPTION
The fix previously got broken by #293 because of their outdated branch and didn't noticed my the merger when merging, thus this change resubmitted