### PR TITLE
Pet Parenting Attempt 2

### DIFF
--- a/constants/parents.json
+++ b/constants/parents.json
@@ -826,6 +826,66 @@
         "WOOD_STEP-4",
         "WOOD_STEP-5"
     ],
+    "BEE;4": [
+        "BEE;3",
+        "BEE;2",
+        "BEE;1",
+        "BEE;0"
+    ],
+    "CHICKEN;4": [
+        "CHICKEN;3",
+        "CHICKEN;2",
+        "CHICKEN;1",
+        "CHICKEN;0"
+    ],
+    "ELEPHANT;4": [
+        "ELEPHANT;3",
+        "ELEPHANT;2",
+        "ELEPHANT;1",
+        "ELEPHANT;0"
+    ],
+    "PIG;4": [
+        "PIG;3",
+        "PIG;2",
+        "PIG;1",
+        "PIG;0"
+    ],
+    "RABBIT;4": [
+        "RABBIT;3",
+        "RABBIT;2",
+        "RABBIT;1",
+        "RABBIT;0"
+    ],
+    "GIRAFFE;4": [
+        "GIRAFFE;3",
+        "GIRAFFE;2",
+        "GIRAFFE;1",
+        "GIRAFFE;0"
+    ],
+    "LION;4": [
+        "LION;3",
+        "LION;2",
+        "LION;1",
+        "LION;0"
+    ],
+    "MONKEY;4": [
+        "MONKEY;3",
+        "MONKEY;2",
+        "MONKEY;1",
+        "MONKEY;0"
+    ],
+    "OCELOT;4": [
+        "OCELOT;3",
+        "OCELOT;2",
+        "OCELOT;1",
+        "OCELOT;0"
+    ],
+    "GUARDIAN;4": [
+        "GUARDIAN;3",
+        "GUARDIAN;2",
+        "GUARDIAN;1",
+        "GUARDIAN;0"
+    ],
     "WOOL": [
         "WOOL-1",
         "WOOL-2",

--- a/constants/parents.json
+++ b/constants/parents.json
@@ -940,6 +940,65 @@
         "SHEEP;1",
         "SHEEP;0"
     ],
+    "ENDERMAN;4": [
+        "ENDERMAN;3",
+        "ENDERMAN;2",
+        "ENDERMAN;1",
+        "ENDERMAN;0"
+    ],
+    "GRIFFIN;4": [
+        "GRIFFIN;3",
+        "GRIFFIN;2",
+        "GRIFFIN;1",
+        "GRIFFIN;0"
+    ],
+    "HORSE;4": [
+        "HORSE;3",
+        "HORSE;2",
+        "HORSE;1",
+        "HORSE;0"
+    ],
+    "JERRY;4": [
+        "JERRY;3",
+        "JERRY;2",
+        "JERRY;1",
+        "JERRY;0"
+    ],
+    "MAGMA_CUBE;4": [
+        "MAGMA_CUBE;3",
+        "MAGMA_CUBE;2",
+        "MAGMA_CUBE;1",
+        "MAGMA_CUBE;0"
+    ],
+    "SKELETON;4": [
+        "SKELETON;3",
+        "SKELETON;2",
+        "SKELETON;1",
+        "SKELETON;0"
+    ],
+    "SPIDER;4": [
+        "SPIDER;3",
+        "SPIDER;2",
+        "SPIDER;1",
+        "SPIDER;0"
+    ],
+    "TIGER;4": [
+        "TIGER;3",
+        "TIGER;2",
+        "TIGER;1",
+        "TIGER;0"
+    ],
+    "ZOMBIE;4": [
+        "ZOMBIE;3",
+        "ZOMBIE;2",
+        "ZOMBIE;1"
+    ],
+    "BEE;4": [
+        "BEE;3",
+        "BEE;2",
+        "BEE;1",
+        "BEE;0"
+    ],
     "WOOL": [
         "WOOL-1",
         "WOOL-2",

--- a/constants/parents.json
+++ b/constants/parents.json
@@ -886,6 +886,60 @@
         "GUARDIAN;1",
         "GUARDIAN;0"
     ],
+    "BAT;4": [
+        "BAT;3",
+        "BAT;2",
+        "BAT;1",
+        "BAT;0"
+    ],
+    "BEE;4": [
+        "BEE;3",
+        "BEE;2",
+        "BEE;1",
+        "BEE;0"
+    ],
+    "ENDERMITE;4": [
+        "ENDERMITE;3",
+        "ENDERMITE;2",
+        "ENDERMITE;1",
+        "ENDERMITE;0"
+    ],
+    "ROCK;4": [
+        "ROCK;3",
+        "ROCK;2",
+        "ROCK;1",
+        "ROCK;0"
+    ],
+    "SILVERFISH;4": [
+        "SILVERFISH;3",
+        "SILVERFISH;2",
+        "SILVERFISH;1",
+        "SILVERFISH;0"
+    ],
+    "BLUE_WHALE;4": [
+        "BLUE_WHALE;3",
+        "BLUE_WHALE;2",
+        "BLUE_WHALE;1",
+        "BLUE_WHALE;0"
+    ],
+    "DOLPHIN;4": [
+        "DOLPHIN;3",
+        "DOLPHIN;2",
+        "DOLPHIN;1",
+        "DOLPHIN;0"
+    ],
+    "SQUID;4": [
+        "SQUID;3",
+        "SQUID;2",
+        "SQUID;1",
+        "SQUID;0"
+    ],
+    "SHEEP;4": [
+        "SHEEP;3",
+        "SHEEP;2",
+        "SHEEP;1",
+        "SHEEP;0"
+    ],
     "WOOL": [
         "WOOL-1",
         "WOOL-2",

--- a/constants/parents.json
+++ b/constants/parents.json
@@ -993,11 +993,54 @@
         "ZOMBIE;2",
         "ZOMBIE;1"
     ],
-    "BEE;4": [
-        "BEE;3",
-        "BEE;2",
-        "BEE;1",
-        "BEE;0"
+    "WITHER_SKELETON;4": [
+        "WITHER_SKELETON;3"
+    ],
+    "ENDER_DRAGON;4": [
+        "ENDER_DRAGON;3"
+    ],
+    "BLAZE;4": [
+        "BLAZE;3"
+    ],
+    "GHOUL;4": [
+        "GHOUL;3"
+    ],
+    "GOLEM;4": [
+        "GOLEM;3"
+    ],
+    "HOUND;4": [
+        "HOUND;3"
+    ],
+    "PHOENIX;4": [
+        "PHOENIX;3"
+    ],
+    "PIGMAN;4": [
+        "PIGMAN;3"
+    ],
+    "SPIRIT;4": [
+        "SPIRIT;3"
+    ],
+    "TARANTULA;4": [
+        "TARANTULA;3"
+    ],
+    "TURTLE;4": [
+        "TURTLE;3"
+    ],
+    "BABY_YETI;4": [
+        "BABY_YETI;3"
+    ],
+    "MEGALODON;4": [
+        "MEGALODON;3"
+    ],
+    "PARROT;4": [
+        "PARROT;3"
+    ],
+    "JELLYFISH;4": [
+        "JELLYFISH;3"
+    ],
+    "FLYING_FISH;4": [
+        "FLYING_FISH;3",
+        "FLYING_FISH;2",
     ],
     "WOOL": [
         "WOOL-1",


### PR DESCRIPTION
Put all pets into parent categories. After community feedback I have put legendary first.

Pets with 5 rarities parented:
Bee, Chicken, Elephant, Pig, Rabbit, Bat, Endermite, Rock, Silverfish, Enderman, Griffin, Horse, Jerry, Magma Cube, Skeleton, Spider, Tiger, Wolf, Giraffe,  Lion, Monkey, Ocelot, Blue Whale, Dolphin, Squid, Guardian, and Sheep.

Pets with 4 rarities parented:
Zombie (only 4 rarities in the repo im just as confused as you are)

Pets with 3 rarities parented:
Flying Fish

Pets with 2 rarities parented:
Wither Skeleton, Blaze, Ender Dragon, Ghoul, Golem, Hound, Phoenix, Pigman, Spirit, Tarantula, Turtle, Baby Yeti, Megaladon, Jellyfish, Parrot.

Pets that were not parented due to having only one rarity:
Black Cat, Skeleton Horse, Snowman

Thats all for today, make sure to vote in the poll in #neu-suggestions-pinned if you want to voice your opinions on whether this should happen.