### PR TITLE
Band-Aid type of fix for hyphenated enchantments + new enchantment pool pairs

### DIFF
--- a/constants/enchants.json
+++ b/constants/enchants.json
@@ -27,7 +27,7 @@
 			"titan_killer",
 			"thunderlord",
 			"thunderbolt",
-			"triple-strike",
+			"triple_strike",
 			"vampirism",
 			"venomous",
 			"vicious",
@@ -63,10 +63,10 @@
 			"telekinesis",
 			"replenish",
 			"silk_touch",
-			"turbo-cacti",
-			"turbo-coco",
-			"turbo-melon",
-			"turbo-pumpkin"
+			"turbo_cacti",
+			"turbo_coco",
+			"turbo_melon",
+			"turbo_pumpkin"
 		],
 		"PICKAXE": [
 			"compact",
@@ -99,12 +99,12 @@
 			"replenish",
 			"harvesting",
 			"telekinesis",
-			"turbo-wheat",
-			"turbo-cane",
-			"turbo-warts",
-			"turbo-carrot",
-			"turbo-potato",
-			"turbo-mushroom"
+			"turbo_wheat",
+			"turbo_cane",
+			"turbo_warts",
+			"turbo_carrot",
+			"turbo_potato",
+			"turbo_mushrooms"
 		],
 		"HELMET": [
 			"big_brain",
@@ -218,6 +218,12 @@
 		], [
 			"depth_strider",
 			"frost_walker"
+		], [
+			"first_strike",
+			"triple_strike"
+		], [
+			"giant_killer",
+			"titan_killer"
 		]
 	],
 	"enchants_min_level": {
@@ -296,16 +302,16 @@
 		"feather_falling": 5,
 		"depth_strider": 3,
 		"thorns": 3,
-		"turbo-wheat": 5,
-		"turbo-cane": 5,
-		"turbo-warts": 5,
-		"turbo-carrot": 5,
-		"turbo-potato": 5,
-		"turbo-mushroom": 5,
-		"turbo-cacti": 5,
-		"turbo-coco": 5,
-		"turbo-melon": 5,
-		"turbo-pumpkin": 5,
+		"turbo_wheat": 5,
+		"turbo_cane": 5,
+		"turbo_warts": 5,
+		"turbo_carrot": 5,
+		"turbo_potato": 5,
+		"turbo_mushrooms": 5,
+		"turbo_cacti": 5,
+		"turbo_coco": 5,
+		"turbo_melon": 5,
+		"turbo_pumpkin": 5,
 		"ultimate_one_for_all": 1,
 		"ultimate_soul_eater": 5,
 		"ultimate_bank": 5,


### PR DESCRIPTION
also added two new enchantment pool pairs (triplestrike/firststrike and giantkiller/titankiller)

i tested this on my own and for some reason it works even though it might not match the name of the enchantment in-game in terms of hyphenation... welp. whatever gets the job done, i guess?

— erymanthus | u/raydeeux