### PR TITLE
Champ rod level req fix

### DIFF
--- a/items/CHAMP_ROD.json
+++ b/items/CHAMP_ROD.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:fishing_rod",
   "displayname": "§9Rod of Champions",
-  "nbttag": "{Unbreakable:1,HideFlags:254,display:{Lore:[0:\"§7Damage: §c+85\",1:\"§7Sea Creature Chance: §c+4%\",2:\"\",3:\"§7Increases fishing speed by §960%\",4:\"\",5:\"§7§8This item can be reforged!\",6:\"§4❣ §cRequires §aFishing Skill 3\",7:\"§9§lRARE FISHING ROD\"],Name:\"§9Rod of Champions\"},ExtraAttributes:{id:\"CHAMP_ROD\"}}",
+  "nbttag": "{Unbreakable:1,HideFlags:254,display:{Lore:[0:\"§7Damage: §c+85\",1:\"§7Sea Creature Chance: §c+4%\",2:\"\",3:\"§7Increases fishing speed by §960%\",4:\"\",5:\"§7§8This item can be reforged!\",6:\"§4❣ §cRequires §aFishing Skill 15\",7:\"§9§lRARE FISHING ROD\"],Name:\"§9Rod of Champions\"},ExtraAttributes:{id:\"CHAMP_ROD\"}}",
   "damage": 0,
   "lore": [
     "§7Damage: §c+85",

--- a/items/CHAMP_ROD.json
+++ b/items/CHAMP_ROD.json
@@ -10,7 +10,7 @@
     "§7Increases fishing speed by §960%",
     "",
     "§7§8This item can be reforged!",
-    "§4❣ §cRequires §aFishing Skill 3",
+    "§4❣ §cRequires §aFishing Skill 15",
     "§9§lRARE FISHING ROD"
   ],
   "recipe": {


### PR DESCRIPTION
Fixed typo where it says the required fishing level to use Rod Of Champions is 3 when it is 15