### PR TITLE
Fix typo in POTATO_CROWN.json

### DIFF
--- a/items/POTATO_CROWN.json
+++ b/items/POTATO_CROWN.json
@@ -10,7 +10,7 @@
     "§7Bestowed by Hypixel to the",
     "§7winner of the Great Potato War.",
     "",
-    "§dAll mean can see the tactics",
+    "§dAll men can see the tactics",
     "§dwhereby I conquer, but what none",
     "§dcan see is the strategy out ",
     "§dwhich victory is evolved.",


### PR DESCRIPTION
I saw the typo in NEU, so I just wanted to fix it.