### PR TITLE
lol prosecute is in full caps in nbt 

### DIFF
--- a/constants/enchants.json
+++ b/constants/enchants.json
@@ -18,7 +18,7 @@
       "life_steal",
       "looting",
       "luck",
-      "prosecute",
+      "PROSECUTE",
       "scavenger",
       "sharpness",
       "smite",
@@ -215,7 +215,7 @@
       "life_steal"
     ], [
       "execute",
-      "prosecute"
+      "PROSECUTE"
     ], [
       "depth_strider",
       "frost_walker"
@@ -235,7 +235,7 @@
     "critical": 5,
     "ender_slayer": 5,
     "execute": 5,
-    "prosecute": 5,
+    "PROSECUTE": 5,
     "fire_aspect": 2,
     "first_strike": 4,
     "triple-strike": 5,


### PR DESCRIPTION
this fixes hold shift to show missing enchants 