### PR TITLE
Fix itemid inconsistencies

### DIFF
--- a/items/DIRT-2.json
+++ b/items/DIRT-2.json
@@ -1,6 +1,6 @@
 {
   "internalname": "DIRT-2",
-  "itemid": 3,
+  "itemid": "minecraft:dirt",
   "displayname": "§fPodzol",
   "clickcommand": "",
   "damage": 2,

--- a/items/TRAINING_WEIGHTS.json
+++ b/items/TRAINING_WEIGHTS.json
@@ -1,6 +1,6 @@
 {
   "internalname": "TRAINING_WEIGHTS",
-  "itemid": 397,
+  "itemid": "minecraft:skull",
   "displayname": "§aTraining Weights",
   "clickcommand": "",
   "damage": 3,


### PR DESCRIPTION
All but the two changed files in `items` have a string `itemid` field that has prefix `minecraft:`.