### PR TITLE
update bazaar stocks

### DIFF
--- a/constants/bazaarstocks.json
+++ b/constants/bazaarstocks.json
@@ -696,6 +696,14 @@
     "id": "ATTRIBUTE_SHARD_YUMMY;1"
   },
   {
+    "stock": "SHARD_TITANOBOA",
+    "id": "ATTRIBUTE_SHARD_BAYOU_BITER;1"
+  },
+  {
+    "stock": "SHARD_HUMMINGBIRD",
+    "id": "ATTRIBUTE_SHARD_CHOP;1"
+  },
+  {
     "stock": "ENCHANTMENT_CORRUPTION_5",
     "id": "CORRUPTION;5"
   },
@@ -2094,6 +2102,10 @@
   {
     "stock": "ENCHANTMENT_FORTUNE_4",
     "id": "FORTUNE;4"
+  },
+  {
+    "stock": "ENCHANTMENT_ARCANE_6",
+    "id": "ARCANE;6"
   },
   {
     "stock": "ENCHANTMENT_ARCANE_5",


### PR DESCRIPTION
adds the 2 new shards + the new book, idk how possible it is to automate this file but that could be good or otherwise we could make the existing action at least log down if there is books/shards in the bz api that are not in this file and therefore need manual adding