### PR TITLE
fix: Mosquito Pet Bonus Pest Chance

### DIFF
--- a/constants/petnums.json
+++ b/constants/petnums.json
@@ -3700,7 +3700,7 @@
           0.5
         ],
         "statNums": {
-          "BONUS_PEST_CHANCE": 0.4,
+          "BONUS_PEST_CHANCE": 0.5,
           "SPEED": 0.2
         }
       },
@@ -3709,7 +3709,7 @@
           50
         ],
         "statNums": {
-          "BONUS_PEST_CHANCE": 40.0,
+          "BONUS_PEST_CHANCE": 50.0,
           "SPEED": 20.0
         }
       }
@@ -3721,7 +3721,7 @@
           0.02
         ],
         "statNums": {
-          "BONUS_PEST_CHANCE": 0.4,
+          "BONUS_PEST_CHANCE": 0.5,
           "SPEED": 0.2
         }
       },
@@ -3731,7 +3731,7 @@
           2
         ],
         "statNums": {
-          "BONUS_PEST_CHANCE": 40.0,
+          "BONUS_PEST_CHANCE": 50.0,
           "SPEED": 20.0
         }
       }
@@ -3743,7 +3743,7 @@
           0.02
         ],
         "statNums": {
-          "BONUS_PEST_CHANCE": 0.4,
+          "BONUS_PEST_CHANCE": 0.5,
           "SPEED": 0.2
         }
       },
@@ -3753,7 +3753,7 @@
           2
         ],
         "statNums": {
-          "BONUS_PEST_CHANCE": 40.0,
+          "BONUS_PEST_CHANCE": 50.0,
           "SPEED": 20.0
         }
       }
@@ -3766,7 +3766,7 @@
           1
         ],
         "statNums": {
-          "BONUS_PEST_CHANCE": 0.4,
+          "BONUS_PEST_CHANCE": 0.5,
           "SPEED": 0.2
         }
       },
@@ -3777,7 +3777,7 @@
           100
         ],
         "statNums": {
-          "BONUS_PEST_CHANCE": 40.0,
+          "BONUS_PEST_CHANCE": 50.0,
           "SPEED": 20.0
         }
       }


### PR DESCRIPTION
Fixes uncommon-leg tiers of mosquito pet having wrong bonus pest chance scaling