### PR TITLE
Add Precursor Apparatus to sack items

### DIFF
--- a/constants/sacks.json
+++ b/constants/sacks.json
@@ -422,7 +422,8 @@
         "SYNTHETIC_HEART",
         "JUNGLE_KEY",
         "WISHING_COMPASS",
-        "ASCENSION_ROPE"
+        "ASCENSION_ROPE",
+        "PRECURSOR_APPARATUS"
       ]
     },
     "Dungeon": {


### PR DESCRIPTION
wow, i'm really unlucky, amn't i

just so i didn't have to do several different PRs for this, i went through all the sacks (that i had) and looked through them found nothing, it was just this one.