### PR TITLE
fix: Eerie rarity in Tyashoi shop

### DIFF
--- a/items/TYASHOI_ALCHEMIST_NPC.json
+++ b/items/TYASHOI_ALCHEMIST_NPC.json
@@ -119,7 +119,7 @@
     },
     {
       "type": "npc_shop",
-      "result": "EERIE;1:1",
+      "result": "EERIE;0:1",
       "cost": [
         "EPHEMERAL_GRATITUDE:2"
       ]


### PR DESCRIPTION
It was saying it's selling an Uncommon Eerie, which... doesn't exist.