### PR TITLE
fix: Mythic Armadillo craft cost

### DIFF
--- a/items/ARMADILLO;5.json
+++ b/items/ARMADILLO;5.json
@@ -46,7 +46,7 @@
   "recipes": [
     {
       "type": "katgrade",
-      "coins": 1500000,
+      "coins": 1000000,
       "time": 3600,
       "input": "ARMADILLO;4",
       "output": "ARMADILLO;5",


### PR DESCRIPTION
Mayor Aura is making all pet upgrades cost 50% more. I fixed the craft cost of Mythic Armadillo to use the base cost.