### PR TITLE
Various Fixes and Lore updates

### DIFF
--- a/items/AQUA_AFFINITY;1.json
+++ b/items/AQUA_AFFINITY;1.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:enchanted_book",
   "displayname": "§fEnchanted Book",
-  "nbttag": "{ExtraAttributes:{enchantments:{aqua_affinity:1},id:\"AQUA_AFFINITY;1\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Aqua Affinity I\",1:\"§7Increases your underwater mining\",2:\"§7rate.\",3:\"\",4:\"§7Use this on an item in an Anvil\",5:\"§7to apply it!\",6:\"\",7:\"§6Source:\",8:\"§aI: §7Enchantment Table,\",9:\"§7Prismarine Crystals Collection\",10:\"\",11:\"§6Applied To:\",12:\"§7- §fHelmet\",13:\"\",14:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[0:{id:6S,lvl:1S}]}",
+  "nbttag": "{ExtraAttributes:{enchantments:{aqua_affinity:1},id:\"AQUA_AFFINITY;1\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Aqua Affinity I\",1:\"§7Increases your underwater mining\",2:\"§7rate.\",3:\"\",4:\"§7Use this on an item in an Anvil\",5:\"§7to apply it!\",6:\"\",7:\"§6Source:\",8:\"§aI: §7Enchantment Table\",9:\"\",10:\"§6Applied To:\",11:\"§7- §fHelmet\",12:\"\",13:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[0:{id:6S,lvl:1S}]}",
   "damage": 0,
   "lore": [
     "§9Aqua Affinity I",
@@ -12,8 +12,7 @@
     "§7to apply it!",
     "",
     "§6Source:",
-    "§aI: §7Enchantment Table,",
-    "§7Prismarine Crystals Collection",
+    "§aI: §7Enchantment Table",
     "",
     "§6Applied To:",
     "§7- §fHelmet",
@@ -23,7 +22,7 @@
   "internalname": "AQUA_AFFINITY;1",
   "clickcommand": "",
   "crafttext": "",
-  "modver": "Firmament 3.4.0-dev+mc1.21.5+g4cd6602",
+  "modver": "Firmament 3.11.0+mc1.21.7",
   "infoType": "",
   "info": []
 }

--- a/items/CHYME.json
+++ b/items/CHYME.json
@@ -1,21 +1,21 @@
 {
   "itemid": "minecraft:skull",
   "displayname": "§9Chyme",
-  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"34832ef3-5399-3bcb-81ec-86f9c7e263d1\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2I4MTcyYzJkZmUzZjk0ZTkyZWVhZjcyZjc4ZmNmNjM0ZTk5NjY1N2ZmNzRkNzNkOTNlNTc4MTUyOGI0NTgzIn19fQ\u003d\u003d\"}]}},display:{Lore:[0:\"§7Feeding this to your pets gives them\",1:\"§7a boost of §a90,000 Exp§7!\",2:\"\",3:\"§7§eRight-click on your summoned pet to\",4:\"§efeed it!\",5:\"\",6:\"§9§lRARE\"],Name:\"§9Chyme\"},ExtraAttributes:{id:\"CHYME\"}}",
+  "nbttag": "{ExtraAttributes:{id:\"CHYME\"},HideFlags:254,ItemModel:\"minecraft:player_head\",SkullOwner:{Id:\"74fa00fb-13e6-3c78-a21d-89589d5cc7e5\",Properties:{textures:[0:{Name:\"textures\",Signature:\"t3RarBGgjlwWwpIMh9ImrYnzntSlwATT571GXf0cecDfhP4MNoW3ltlQYunORnvaoZJ2s3q2wY4gIb85FJBprTgF+AGq4xK3JhHYSJ9kRl0b/7cZEocLydgAB8soXQzmzWlpvs0maG48v6lyAwuCTcGAOAezM2AmN3G4gpDl0jcbrpWEqUbWywWAWLl0/NK7I5DQR1y/s219Nc/sWQYH47pHLwNG+5zTXS+gfXnjrkDE6/X4OIf3GW0WyxxMq7YxA2cx2SP3J8cOwl01cq9P25h7mXxrEQ+0lmpJlmLtn3wIss+S4qHbqOyL5BuLtGmf9em7wrLMNN+9D9kGP1hW1MFJj/1dCP18EBh5o0PimpD999LcRNLyPnjn7Hf6pBgHzhJ0fp+LRCVIYHbpukbWc2f8MPzdBCrqWH3JdNomEm9VJ7ALv/CAo0OncRuqLOyvksfitJscuhWsHE692kwUV/rUdbob1EMzXeGpZykuMcyLExeX0rbN5hAcUhJgzf/vla4QbssfZ4cbJjQ0urcc/DZMqzFJwqzArUef3JcrcjlM4Z1REMS3axvQ00z7bTtKJ1dMxeR3N39TyCe0IJYgbuQGXf6nBxI3eRZH/NIHywLqOj9VcdoYQZPodhRJo0sJ9fcjVjFpUdmH3tIMnjTnhOAGYKY2jBSgO/jYtMjcjAM=\",Value:\"ewogICJ0aW1lc3RhbXAiIDogMTYzMjk3NTg3ODEwNCwKICAicHJvZmlsZUlkIiA6ICIwYTUzMDU0MTM4YWI0YjIyOTVhMGNlZmJiMGU4MmFkYiIsCiAgInByb2ZpbGVOYW1lIiA6ICJQX0hpc2lybyIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS80M2YxMmExM2Y5ZmRiOTZjMjU4ZDE4ZjY2ZjdhOWIzZDExOTU1OTFmYjJjNWIzMWFkNjIwNWU4Y2Q0NmFhZGE5IgogICAgfQogIH0KfQ==\"}]},hypixelPopulated:1B},display:{Lore:[0:\"§7Feeding this to your pets gives them\",1:\"§7a boost of §a90,000 Exp§7!\",2:\"\",3:\"§eRight-click on your summoned pet to\",4:\"§efeed it!\",5:\"\",6:\"§9§lRARE\"],Name:\"§9Chyme\"}}",
   "damage": 3,
   "lore": [
     "§7Feeding this to your pets gives them",
     "§7a boost of §a90,000 Exp§7!",
     "",
-    "§7§eRight-click on your summoned pet to",
+    "§eRight-click on your summoned pet to",
     "§efeed it!",
     "",
     "§9§lRARE"
   ],
   "internalname": "CHYME",
-  "crafttext": "",
   "clickcommand": "",
-  "modver": "",
+  "crafttext": "",
+  "modver": "Firmament 42.0.0+mc1.21.7",
   "infoType": "WIKI_URL",
   "info": [
     "https://hypixel-skyblock.fandom.com/wiki/Chyme",

--- a/items/DAEDALUS_AXE.json
+++ b/items/DAEDALUS_AXE.json
@@ -26,7 +26,7 @@
   "internalname": "DAEDALUS_AXE",
   "clickcommand": "viewrecipe",
   "crafttext": "",
-  "modver": "Firmament 3.7.1-dev+mc1.21.5+gf7e1a13",
+  "modver": "Firmament 42.0.0+mc1.21.7",
   "infoType": "WIKI_URL",
   "info": [
     "https://hypixel-skyblock.fandom.com/wiki/Daedalus_Blade",
@@ -34,15 +34,15 @@
   ],
   "recipes": [
     {
-      "A1": "",
-      "A2": "ENCHANTED_GOLD_BLOCK:24",
-      "A3": "",
-      "B1": "",
-      "B2": "ENCHANTED_GOLD_BLOCK:24",
-      "B3": "",
-      "C1": "",
-      "C2": "DAEDALUS_STICK:1",
-      "C3": "",
+      "A1": "ENCHANTED_GOLD_BLOCK:8",
+      "A2": "DAEDALUS_STICK",
+      "A3": "ENCHANTED_GOLD_BLOCK:8",
+      "B1": "ENCHANTED_GOLD_BLOCK:8",
+      "B2": "SWORD_OF_REVELATIONS",
+      "B3": "ENCHANTED_GOLD_BLOCK:8",
+      "C1": "ENCHANTED_GOLD_BLOCK:8",
+      "C2": "DAEDALUS_STICK",
+      "C3": "ENCHANTED_GOLD_BLOCK:8",
       "type": "crafting",
       "count": 1,
       "overrideOutputId": "DAEDALUS_AXE"

--- a/items/ENDER_SLAYER;6.json
+++ b/items/ENDER_SLAYER;6.json
@@ -1,12 +1,12 @@
 {
   "itemid": "minecraft:enchanted_book",
   "displayname": "§9Enchanted Book",
-  "nbttag": "{ExtraAttributes:{enchantments:{ender_slayer:6},id:\"ENDER_SLAYER;6\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Ender Slayer VI\",1:\"§7Increases damage dealt to §5⊙ Ender\",2:\"§7mobs by §a100%§7.\",3:\"\",4:\"§7Use this on an item in an Anvil\",5:\"§7to apply it!\",6:\"\",7:\"§6Source:\",8:\"§aVI: §7Pearl Dealer\",9:\"\",10:\"§6Applied To:\",11:\"§7- §fSword\",12:\"§7- §fFishing Weapon\",13:\"§7- §fLongsword\",14:\"§7- §fGauntlet\",15:\"\",16:\"§9§lRARE\"],Name:\"§9Enchanted Book\"},ench:[]}",
+  "nbttag": "{ExtraAttributes:{enchantments:{ender_slayer:6},id:\"ENDER_SLAYER;6\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Ender Slayer VI\",1:\"§7Increases damage dealt to §5⊙ Ender\",2:\"§7mobs by §a40%§7.\",3:\"\",4:\"§7Use this on an item in an Anvil\",5:\"§7to apply it!\",6:\"\",7:\"§6Source:\",8:\"§aVI: §7Pearl Dealer\",9:\"\",10:\"§6Applied To:\",11:\"§7- §fSword\",12:\"§7- §fFishing Weapon\",13:\"§7- §fLongsword\",14:\"§7- §fGauntlet\",15:\"\",16:\"§9§lRARE\"],Name:\"§9Enchanted Book\"},ench:[]}",
   "damage": 0,
   "lore": [
     "§9Ender Slayer VI",
     "§7Increases damage dealt to §5⊙ Ender",
-    "§7mobs by §a100%§7.",
+    "§7mobs by §a40%§7.",
     "",
     "§7Use this on an item in an Anvil",
     "§7to apply it!",
@@ -25,7 +25,7 @@
   "internalname": "ENDER_SLAYER;6",
   "clickcommand": "",
   "crafttext": "",
-  "modver": "Firmament 3.4.0-dev+mc1.21.5+g4cd6602",
+  "modver": "Firmament 42.0.0+mc1.21.7",
   "infoType": "",
   "info": [],
   "parent": "ENDER_SLAYER;4",

--- a/items/GIFT_OF_LEARNING.json
+++ b/items/GIFT_OF_LEARNING.json
@@ -1,22 +1,21 @@
 {
   "itemid": "minecraft:skull",
   "displayname": "§9Gift of Learning",
-  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"a68b0262-2d46-3a9f-9dfa-9d6791869a6d\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMmU5YjMzNWMwYjEzMWFhNGNlZjc4MjAzZDhmNWJhNTJkMjZmNTg0NTJjY2IxNTU3OThhY2Q0YmRjNzQ1MTczIn19fQ\u003d\u003d\"}]}},display:{Lore:[0:\"§7Allows you to grant §310,000 Exp\",1:\"§3§7in a §3Skill §7of your\",2:\"§7choosing!\",3:\"\",4:\"§eClick to open!\",5:\"\",6:\"§8§l* §8Soulbound §8§l*\",7:\"§9§lRARE\"],Name:\"§9Gift of Learning\"},ExtraAttributes:{yearObtained:2023,id:\"GIFT_OF_LEARNING\"}}",
+  "nbttag": "{ExtraAttributes:{id:\"GIFT_OF_LEARNING\",yearObtained:2024},HideFlags:254,ItemModel:\"minecraft:player_head\",SkullOwner:{Id:\"c5d6d085-796d-3d12-9377-4e180f768af3\",Properties:{textures:[0:{Name:\"textures\",Signature:\"lh0G+KTyLQEXWRrACEI5LMgARRzlp/B2izSHh/9WG05Jgr2G6nOs1IKb3LfcknJdJY7glEr1Wlsl9Id/MQVggRip01Kbd539sldwLKnEnCrT3geXC8U5T9J/caKNdysCLhjvikn7S2UjMthAXm0IJG+9YAzWSTJbeZm0g0cjZpLASLnDozQLKbArqTmexQtHhkNWNfwX1llBi8G3UAdATxoAdX7KrX4yPQF6O1YlX078ct1/kUlEXrYsuZVqKcGw/z7CVX5OGoUa5ovdzlk2aiipxJhI6PyH2e8VtP898o+wGLkr+vFljfvKHieZWZteQlK1YwLc9CoDWFfuXZ22GkGYpxhrXGlgz1SFAX6j71bNOXofLvnfQQchY44rSJsp3VPa4p7LlYVSJ58BBU+BZxP8MM/acQVLwdXxHwOHebgIoJJKTFQYUiu4KSz9K0Jq+E2r6/b2plnQaMicdX/sQEimbL4aA9JmGyEVzKEiRJ3PoKtMEGwaJ1PYUZ029gvjGZXfxvULFhxWbaOsWIrm8qXeQ0JuEqYn8mHZx8IKtesa+aFPXu3lpmNOKeXkJDXi7C38CgZHBTkug3D3dhy8aaz1LwXp4XjaSwzaZWvxWVLFu9XMTMWIXar0kdYOha01Bm6NLqZ2Q+IxMFu1dx9lt5kaAuvEbADGu42BHhos1D4=\",Value:\"ewogICJ0aW1lc3RhbXAiIDogMTcyMDA0MjQzODg3MCwKICAicHJvZmlsZUlkIiA6ICJmMjc0YzRkNjI1MDQ0ZTQxOGVmYmYwNmM3NWIyMDIxMyIsCiAgInByb2ZpbGVOYW1lIiA6ICJIeXBpZ3NlbCIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8yZTliMzM1YzBiMTMxYWE0Y2VmNzgyMDNkOGY1YmE1MmQyNmY1ODQ1MmNjYjE1NTc5OGFjZDRiZGM3NDUxNzMiLAogICAgICAibWV0YWRhdGEiIDogewogICAgICAgICJtb2RlbCIgOiAic2xpbSIKICAgICAgfQogICAgfQogIH0KfQ==\"}]},hypixelPopulated:1B},display:{Lore:[0:\"§7Allows you to grant §310,000 Exp §7in a\",1:\"§3Skill §7of your choosing!\",2:\"\",3:\"§eRight-click to open!\",4:\"\",5:\"§8§l* §8Soulbound §8§l*\",6:\"§9§lRARE\"],Name:\"§9Gift of Learning\"}}",
   "damage": 3,
   "lore": [
-    "§7Allows you to grant §310,000 Exp",
-    "§3§7in a §3Skill §7of your",
-    "§7choosing!",
+    "§7Allows you to grant §310,000 Exp §7in a",
+    "§3Skill §7of your choosing!",
     "",
-    "§eClick to open!",
+    "§eRight-click to open!",
     "",
     "§8§l* §8Soulbound §8§l*",
     "§9§lRARE"
   ],
   "internalname": "GIFT_OF_LEARNING",
-  "crafttext": "",
   "clickcommand": "",
-  "modver": "2.1.1-PRE",
+  "crafttext": "",
+  "modver": "Firmament 42.0.0+mc1.21.7",
   "infoType": "WIKI_URL",
   "info": [
     "https://hypixel-skyblock.fandom.com/wiki/Gift_of_Learning",

--- a/items/SEWER_FISH.json
+++ b/items/SEWER_FISH.json
@@ -1,19 +1,18 @@
 {
   "itemid": "minecraft:fish",
   "displayname": "§aSewer Fish",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§7Where did you find these? They\",1:\"§7stink!\",2:\"\",3:\"§8§l* §8Co-op Soulbound §8§l*\",4:\"§a§lUNCOMMON\"],Name:\"§aSewer Fish\"},ExtraAttributes:{id:\"SEWER_FISH\"}}",
+  "nbttag": "{ExtraAttributes:{id:\"SEWER_FISH\"},HideFlags:254,ItemModel:\"minecraft:cod\",display:{Lore:[0:\"§7Where did you find these? They stink!\",1:\"\",2:\"§8§l* §8Co-op Soulbound §8§l*\",3:\"§a§lUNCOMMON\"],Name:\"§aSewer Fish\"}}",
   "damage": 0,
   "lore": [
-    "§7Where did you find these? They",
-    "§7stink!",
+    "§7Where did you find these? They stink!",
     "",
     "§8§l* §8Co-op Soulbound §8§l*",
     "§a§lUNCOMMON"
   ],
   "internalname": "SEWER_FISH",
-  "crafttext": "",
   "clickcommand": "",
-  "modver": "2.1.1-PRE",
+  "crafttext": "",
+  "modver": "Firmament 42.0.0+mc1.21.7",
   "infoType": "WIKI_URL",
   "info": [
     "https://hypixel-skyblock.fandom.com/wiki/Sewer_Fish",

--- a/items/TURBO_WHEAT;1.json
+++ b/items/TURBO_WHEAT;1.json
@@ -1,12 +1,11 @@
 {
   "itemid": "minecraft:enchanted_book",
   "displayname": "§fEnchanted Book",
-  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:1},id:\"TURBO_WHEAT;1\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat I\",1:\"§7Grants §a+5 §6☘ Farming Fortune\",2:\"§7when breaking wheat.\",3:\"\",4:\"§7Use this on an item in an Anvil\",5:\"§7to apply it!\",6:\"\",7:\"§6Source:\",8:\"§aI-V: §7Jacobs Farming contest\",9:\"\",10:\"§6Applied To:\",11:\"§f- Hoe\",12:\"\",13:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[]}",
+  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:1},id:\"TURBO_WHEAT;1\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat I\",1:\"§7Grants §6+5☘ Wheat Fortune§7.\",2:\"\",3:\"§7Use this on an item in an Anvil\",4:\"§7to apply it!\",5:\"\",6:\"§6Source:\",7:\"§aI-V: §7Jacobs Farming contest\",8:\"\",9:\"§6Applied To:\",10:\"§f- Hoe\",11:\"\",12:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[]}",
   "damage": 0,
   "lore": [
     "§9Turbo-Wheat I",
-    "§7Grants §a+5 §6☘ Farming Fortune",
-    "§7when breaking wheat.",
+    "§7Grants §6+5☘ Wheat Fortune§7.",
     "",
     "§7Use this on an item in an Anvil",
     "§7to apply it!",
@@ -22,7 +21,7 @@
   "internalname": "TURBO_WHEAT;1",
   "clickcommand": "",
   "crafttext": "",
-  "modver": "Firmament 3.4.0-dev+mc1.21.5+g4cd6602",
+  "modver": "Firmament 3.11.0+mc1.21.7",
   "infoType": "",
   "info": []
 }

--- a/items/TURBO_WHEAT;2.json
+++ b/items/TURBO_WHEAT;2.json
@@ -1,12 +1,11 @@
 {
   "itemid": "minecraft:enchanted_book",
   "displayname": "§fEnchanted Book",
-  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:2},id:\"TURBO_WHEAT;2\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat II\",1:\"§7Grants §a+10 §6☘ Farming Fortune\",2:\"§7when breaking wheat.\",3:\"\",4:\"§7Use this on an item in an Anvil\",5:\"§7to apply it!\",6:\"\",7:\"§6Source:\",8:\"§aI-V: §7Jacobs Farming contest\",9:\"\",10:\"§6Applied To:\",11:\"§f- Hoe\",12:\"\",13:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[]}",
+  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:2},id:\"TURBO_WHEAT;2\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat II\",1:\"§7Grants §6+10☘ Wheat Fortune§7.\",2:\"\",3:\"§7Use this on an item in an Anvil\",4:\"§7to apply it!\",5:\"\",6:\"§6Source:\",7:\"§aI-V: §7Jacobs Farming contest\",8:\"\",9:\"§6Applied To:\",10:\"§f- Hoe\",11:\"\",12:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[]}",
   "damage": 0,
   "lore": [
     "§9Turbo-Wheat II",
-    "§7Grants §a+10 §6☘ Farming Fortune",
-    "§7when breaking wheat.",
+    "§7Grants §6+10☘ Wheat Fortune§7.",
     "",
     "§7Use this on an item in an Anvil",
     "§7to apply it!",
@@ -22,7 +21,7 @@
   "internalname": "TURBO_WHEAT;2",
   "clickcommand": "",
   "crafttext": "",
-  "modver": "Firmament 3.4.0-dev+mc1.21.5+g4cd6602",
+  "modver": "Firmament 3.11.0+mc1.21.7",
   "infoType": "",
   "info": [],
   "parent": "TURBO_WHEAT;1"

--- a/items/TURBO_WHEAT;3.json
+++ b/items/TURBO_WHEAT;3.json
@@ -1,12 +1,11 @@
 {
   "itemid": "minecraft:enchanted_book",
   "displayname": "§fEnchanted Book",
-  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:3},id:\"TURBO_WHEAT;3\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat III\",1:\"§7Grants §a+15 §6☘ Farming Fortune\",2:\"§7when breaking wheat.\",3:\"\",4:\"§7Use this on an item in an Anvil\",5:\"§7to apply it!\",6:\"\",7:\"§6Source:\",8:\"§aI-V: §7Jacobs Farming contest\",9:\"\",10:\"§6Applied To:\",11:\"§f- Hoe\",12:\"\",13:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[]}",
+  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:3},id:\"TURBO_WHEAT;3\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat III\",1:\"§7Grants §6+15☘ Wheat Fortune§7.\",2:\"\",3:\"§7Use this on an item in an Anvil\",4:\"§7to apply it!\",5:\"\",6:\"§6Source:\",7:\"§aI-V: §7Jacobs Farming contest\",8:\"\",9:\"§6Applied To:\",10:\"§f- Hoe\",11:\"\",12:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[]}",
   "damage": 0,
   "lore": [
     "§9Turbo-Wheat III",
-    "§7Grants §a+15 §6☘ Farming Fortune",
-    "§7when breaking wheat.",
+    "§7Grants §6+15☘ Wheat Fortune§7.",
     "",
     "§7Use this on an item in an Anvil",
     "§7to apply it!",
@@ -22,7 +21,7 @@
   "internalname": "TURBO_WHEAT;3",
   "clickcommand": "",
   "crafttext": "",
-  "modver": "Firmament 3.4.0-dev+mc1.21.5+g4cd6602",
+  "modver": "Firmament 3.11.0+mc1.21.7",
   "infoType": "",
   "info": [],
   "parent": "TURBO_WHEAT;1"

--- a/items/TURBO_WHEAT;4.json
+++ b/items/TURBO_WHEAT;4.json
@@ -1,13 +1,12 @@
 {
   "itemid": "minecraft:enchanted_book",
   "displayname": "§fEnchanted Book",
-  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:4},id:\"TURBO_WHEAT;4\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat IV\",1:\"§7Grants §a+20 §6☘ Farming Fortune\",2:\"§7when breaking wheat.\",3:\"§7Requires §cBronze §7in §awheat Contest§7!\",4:\"\",5:\"§7Use this on an item in an Anvil\",6:\"§7to apply it!\",7:\"\",8:\"§6Source:\",9:\"§aI-V: §7Jacobs Farming contest\",10:\"\",11:\"§6Applied To:\",12:\"§f- Hoe\",13:\"\",14:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[]}",
+  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:4},id:\"TURBO_WHEAT;4\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat IV\",1:\"§7Grants §6+20☘ Wheat Fortune§7.\",2:\"§7Requires §cBronze §7in §aWheat Contest§7!\",3:\"\",4:\"§7Use this on an item in an Anvil\",5:\"§7to apply it!\",6:\"\",7:\"§6Source:\",8:\"§aI-V: §7Jacobs Farming contest\",9:\"\",10:\"§6Applied To:\",11:\"§f- Hoe\",12:\"\",13:\"§f§lCOMMON\"],Name:\"§fEnchanted Book\"},ench:[]}",
   "damage": 0,
   "lore": [
     "§9Turbo-Wheat IV",
-    "§7Grants §a+20 §6☘ Farming Fortune",
-    "§7when breaking wheat.",
-    "§7Requires §cBronze §7in §awheat Contest§7!",
+    "§7Grants §6+20☘ Wheat Fortune§7.",
+    "§7Requires §cBronze §7in §aWheat Contest§7!",
     "",
     "§7Use this on an item in an Anvil",
     "§7to apply it!",
@@ -23,7 +22,7 @@
   "internalname": "TURBO_WHEAT;4",
   "clickcommand": "",
   "crafttext": "",
-  "modver": "Firmament 3.4.0-dev+mc1.21.5+g4cd6602",
+  "modver": "Firmament 3.11.0+mc1.21.7",
   "infoType": "",
   "info": [],
   "parent": "TURBO_WHEAT;1"

--- a/items/TURBO_WHEAT;5.json
+++ b/items/TURBO_WHEAT;5.json
@@ -1,13 +1,12 @@
 {
   "itemid": "minecraft:enchanted_book",
   "displayname": "§aEnchanted Book",
-  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:5},id:\"TURBO_WHEAT;5\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat V\",1:\"§7Grants §a+25 §6☘ Farming Fortune\",2:\"§7when breaking wheat.\",3:\"§7Requires §fSilver §7in §awheat Contest§7!\",4:\"\",5:\"§7Use this on an item in an Anvil\",6:\"§7to apply it!\",7:\"\",8:\"§6Source:\",9:\"§aI-V: §7Jacobs Farming contest\",10:\"\",11:\"§6Applied To:\",12:\"§f- Hoe\",13:\"\",14:\"§a§lUNCOMMON\"],Name:\"§aEnchanted Book\"},ench:[]}",
+  "nbttag": "{ExtraAttributes:{enchantments:{turbo_wheat:5},id:\"TURBO_WHEAT;5\"},HideFlags:254,ItemModel:\"minecraft:enchanted_book\",display:{Lore:[0:\"§9Turbo-Wheat V\",1:\"§7Grants §6+25☘ Wheat Fortune§7.\",2:\"§7Requires §fSilver §7in §aWheat Contest§7!\",3:\"\",4:\"§7Use this on an item in an Anvil\",5:\"§7to apply it!\",6:\"\",7:\"§6Source:\",8:\"§aI-V: §7Jacobs Farming contest\",9:\"\",10:\"§6Applied To:\",11:\"§f- Hoe\",12:\"\",13:\"§a§lUNCOMMON\"],Name:\"§aEnchanted Book\"},ench:[]}",
   "damage": 0,
   "lore": [
     "§9Turbo-Wheat V",
-    "§7Grants §a+25 §6☘ Farming Fortune",
-    "§7when breaking wheat.",
-    "§7Requires §fSilver §7in §awheat Contest§7!",
+    "§7Grants §6+25☘ Wheat Fortune§7.",
+    "§7Requires §fSilver §7in §aWheat Contest§7!",
     "",
     "§7Use this on an item in an Anvil",
     "§7to apply it!",
@@ -23,7 +22,7 @@
   "internalname": "TURBO_WHEAT;5",
   "clickcommand": "",
   "crafttext": "",
-  "modver": "Firmament 3.4.0-dev+mc1.21.5+g4cd6602",
+  "modver": "Firmament 3.11.0+mc1.21.7",
   "infoType": "",
   "info": [],
   "parent": "TURBO_WHEAT;1"

--- a/itemsOverlay/4440/CHYME.snbt
+++ b/itemsOverlay/4440/CHYME.snbt
@@ -1,0 +1,44 @@
+{
+	components: {
+		"minecraft:custom_data": {
+			id: "CHYME"
+		},
+		"minecraft:profile": {
+			id: [I;
+				1962541307,
+				333855864,
+				-1575122600,
+				-1654863899
+			],
+			properties: [
+				{
+					name: "textures",
+					signature: "t3RarBGgjlwWwpIMh9ImrYnzntSlwATT571GXf0cecDfhP4MNoW3ltlQYunORnvaoZJ2s3q2wY4gIb85FJBprTgF+AGq4xK3JhHYSJ9kRl0b/7cZEocLydgAB8soXQzmzWlpvs0maG48v6lyAwuCTcGAOAezM2AmN3G4gpDl0jcbrpWEqUbWywWAWLl0/NK7I5DQR1y/s219Nc/sWQYH47pHLwNG+5zTXS+gfXnjrkDE6/X4OIf3GW0WyxxMq7YxA2cx2SP3J8cOwl01cq9P25h7mXxrEQ+0lmpJlmLtn3wIss+S4qHbqOyL5BuLtGmf9em7wrLMNN+9D9kGP1hW1MFJj/1dCP18EBh5o0PimpD999LcRNLyPnjn7Hf6pBgHzhJ0fp+LRCVIYHbpukbWc2f8MPzdBCrqWH3JdNomEm9VJ7ALv/CAo0OncRuqLOyvksfitJscuhWsHE692kwUV/rUdbob1EMzXeGpZykuMcyLExeX0rbN5hAcUhJgzf/vla4QbssfZ4cbJjQ0urcc/DZMqzFJwqzArUef3JcrcjlM4Z1REMS3axvQ00z7bTtKJ1dMxeR3N39TyCe0IJYgbuQGXf6nBxI3eRZH/NIHywLqOj9VcdoYQZPodhRJo0sJ9fcjVjFpUdmH3tIMnjTnhOAGYKY2jBSgO/jYtMjcjAM=",
+					value: "ewogICJ0aW1lc3RhbXAiIDogMTYzMjk3NTg3ODEwNCwKICAicHJvZmlsZUlkIiA6ICIwYTUzMDU0MTM4YWI0YjIyOTVhMGNlZmJiMGU4MmFkYiIsCiAgInByb2ZpbGVOYW1lIiA6ICJQX0hpc2lybyIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS80M2YxMmExM2Y5ZmRiOTZjMjU4ZDE4ZjY2ZjdhOWIzZDExOTU1OTFmYjJjNWIzMWFkNjIwNWU4Y2Q0NmFhZGE5IgogICAgfQogIH0KfQ=="
+				}
+			]
+		},
+		"minecraft:tooltip_display": {
+			hidden_components: [
+				"minecraft:jukebox_playable",
+				"minecraft:painting/variant",
+				"minecraft:map_id",
+				"minecraft:fireworks",
+				"minecraft:attribute_modifiers",
+				"minecraft:unbreakable",
+				"minecraft:written_book_content",
+				"minecraft:banner_patterns",
+				"minecraft:trim",
+				"minecraft:potion_contents",
+				"minecraft:block_entity_data",
+				"minecraft:dyed_color"
+			]
+		}
+	},
+	count: 1,
+	id: "minecraft:player_head",
+	source: {
+		dataVersion: 4440,
+		modVersion: "Firmament 3.11.0+mc1.21.7"
+	}
+}

--- a/itemsOverlay/4440/GIFT_OF_LEARNING.snbt
+++ b/itemsOverlay/4440/GIFT_OF_LEARNING.snbt
@@ -1,0 +1,45 @@
+{
+	components: {
+		"minecraft:custom_data": {
+			id: "GIFT_OF_LEARNING",
+			yearObtained: 2024
+		},
+		"minecraft:profile": {
+			id: [I;
+				-975777659,
+				2037202194,
+				-1820897768,
+				259427059
+			],
+			properties: [
+				{
+					name: "textures",
+					signature: "lh0G+KTyLQEXWRrACEI5LMgARRzlp/B2izSHh/9WG05Jgr2G6nOs1IKb3LfcknJdJY7glEr1Wlsl9Id/MQVggRip01Kbd539sldwLKnEnCrT3geXC8U5T9J/caKNdysCLhjvikn7S2UjMthAXm0IJG+9YAzWSTJbeZm0g0cjZpLASLnDozQLKbArqTmexQtHhkNWNfwX1llBi8G3UAdATxoAdX7KrX4yPQF6O1YlX078ct1/kUlEXrYsuZVqKcGw/z7CVX5OGoUa5ovdzlk2aiipxJhI6PyH2e8VtP898o+wGLkr+vFljfvKHieZWZteQlK1YwLc9CoDWFfuXZ22GkGYpxhrXGlgz1SFAX6j71bNOXofLvnfQQchY44rSJsp3VPa4p7LlYVSJ58BBU+BZxP8MM/acQVLwdXxHwOHebgIoJJKTFQYUiu4KSz9K0Jq+E2r6/b2plnQaMicdX/sQEimbL4aA9JmGyEVzKEiRJ3PoKtMEGwaJ1PYUZ029gvjGZXfxvULFhxWbaOsWIrm8qXeQ0JuEqYn8mHZx8IKtesa+aFPXu3lpmNOKeXkJDXi7C38CgZHBTkug3D3dhy8aaz1LwXp4XjaSwzaZWvxWVLFu9XMTMWIXar0kdYOha01Bm6NLqZ2Q+IxMFu1dx9lt5kaAuvEbADGu42BHhos1D4=",
+					value: "ewogICJ0aW1lc3RhbXAiIDogMTcyMDA0MjQzODg3MCwKICAicHJvZmlsZUlkIiA6ICJmMjc0YzRkNjI1MDQ0ZTQxOGVmYmYwNmM3NWIyMDIxMyIsCiAgInByb2ZpbGVOYW1lIiA6ICJIeXBpZ3NlbCIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8yZTliMzM1YzBiMTMxYWE0Y2VmNzgyMDNkOGY1YmE1MmQyNmY1ODQ1MmNjYjE1NTc5OGFjZDRiZGM3NDUxNzMiLAogICAgICAibWV0YWRhdGEiIDogewogICAgICAgICJtb2RlbCIgOiAic2xpbSIKICAgICAgfQogICAgfQogIH0KfQ=="
+				}
+			]
+		},
+		"minecraft:tooltip_display": {
+			hidden_components: [
+				"minecraft:jukebox_playable",
+				"minecraft:painting/variant",
+				"minecraft:map_id",
+				"minecraft:fireworks",
+				"minecraft:attribute_modifiers",
+				"minecraft:unbreakable",
+				"minecraft:written_book_content",
+				"minecraft:banner_patterns",
+				"minecraft:trim",
+				"minecraft:potion_contents",
+				"minecraft:block_entity_data",
+				"minecraft:dyed_color"
+			]
+		}
+	},
+	count: 1,
+	id: "minecraft:player_head",
+	source: {
+		dataVersion: 4440,
+		modVersion: "Firmament 42.0.0+mc1.21.7"
+	}
+}

--- a/mining/blocks/umber.json
+++ b/mining/blocks/umber.json
@@ -27,6 +27,14 @@
         "mineshaft",
         "mining_3"
       ]
+    },
+    {
+      "itemId": "minecraft:smooth_red_sandstone",
+      "damage": 0,
+      "onlyIn": [
+        "mineshaft",
+        "mining_3"
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Fixed Turbo Wheat being outdated
- Fixed Ender Slayer 6 having the wrong percentage
- Fixed Aqua Affinity still claiming to be obtained from Prismarine Collection
- Fixed Chyme, Sewer Fish, and Gift of Learning having outdated lore
- Fixed Daedalus Blade recipe
- Added Smooth Red Sandstone to Jade support for Umber