### PR TITLE
Update Max Fairy Souls count to 267

### DIFF
--- a/constants/fairy_souls.json
+++ b/constants/fairy_souls.json
@@ -1,6 +1,6 @@
 {
   "//": "If you would like to contribute to this list please ensure that you: take the coordinates of the soul its self and not where you stand.",
-  "Max Souls": 266,
+  "Max Souls": 267,
   "hub": [
     "138,66,129",
     "169,60,129",


### PR DESCRIPTION
The Greenhouse update added a new miscellaneous Fairy Soul, so this updates the total count (which Skyblocker uses for its Dungeons Quiz solver).