### PR TITLE
fix: Legendary Griffin Upgrade Stone & Prime Lushlilac Bonbon recipe

### DIFF
--- a/items/GRIFFIN_UPGRADE_STONE_LEGENDARY.json
+++ b/items/GRIFFIN_UPGRADE_STONE_LEGENDARY.json
@@ -20,9 +20,9 @@
   ],
   "recipes": [
     {
-      "A1": "GRIFFIN_FEATHER:64",
-      "A2": "MYTHOS_FRAGMENT:16",
-      "A3": "GRIFFIN_FEATHER:64",
+      "A1": "MYTHOS_FRAGMENT:8",
+      "A2": "BRAIDED_GRIFFIN_FEATHER:1",
+      "A3": "MYTHOS_FRAGMENT:8",
       "B1": "ENCHANTED_ANCIENT_CLAW:16",
       "B2": "BASE_GRIFFIN_UPGRADE_STONE:1",
       "B3": "ENCHANTED_ANCIENT_CLAW:16",

--- a/items/PRIME_LUSHLILAC_BONBON.json
+++ b/items/PRIME_LUSHLILAC_BONBON.json
@@ -26,15 +26,15 @@
   ],
   "recipes": [
     {
-      "A1": "LUSHLILAC:3",
-      "A2": "SEA_LUMIES:16",
-      "A3": "LUSHLILAC:3",
-      "B1": "SEA_LUMIES:16",
+      "A1": "SEA_LUMIES:16",
+      "A2": "LUSHLILAC:3",
+      "A3": "SEA_LUMIES:16",
+      "B1": "LUSHLILAC:3",
       "B2": "",
-      "B3": "SEA_LUMIES:16",
-      "C1": "LUSHLILAC:3",
-      "C2": "SEA_LUMIES:16",
-      "C3": "LUSHLILAC:3",
+      "B3": "LUSHLILAC:3",
+      "C1": "SEA_LUMIES:16",
+      "C2": "LUSHLILAC:3",
+      "C3": "SEA_LUMIES:16",
       "type": "crafting",
       "count": 1,
       "overrideOutputId": "PRIME_LUSHLILAC_BONBON"


### PR DESCRIPTION
Someone changed these incorrectly assuming they follow the new layout for Epic Griffin Upgrade  Stone & Lushlilac Bonbon, but in fact they were intentionally made to use a different layout because Hypixel's spaghetti code doesn't allow them to have two recipes with the exact same items and only differing amounts without making the ones with lower amounts uncraftable without quick craft/supercraft.