### PR TITLE
Modify enchant pools

### DIFF
--- a/constants/enchants.json
+++ b/constants/enchants.json
@@ -666,7 +666,7 @@
       "turbo_wheat",
       "turbo_rose",
       "turbo_moonflower",
-      "turbo_sunflower",
+      "turbo_sunflower"
     ],
     [
       "hardened_mana",


### PR DESCRIPTION
Removed "sharpness", "bane_of_arthropods", and "smite" as conflicting enchants, and added "turbo_rose", "turbo_moonflower", and "turbo_sunflower" as conflicting ones.