### PR TITLE
update potato ring recipe from 24.2 update

### DIFF
--- a/items/POTATO_RING.json
+++ b/items/POTATO_RING.json
@@ -17,22 +17,22 @@
   "internalname": "POTATO_RING",
   "clickcommand": "",
   "crafttext": "",
-  "modver": "Firmament 4.1.0+mc1.21.10",
+  "modver": "Firmament 43.0.0+mc1.21.10",
   "infoType": "WIKI_URL",
   "info": [
     "https://hypixel-skyblock.fandom.com/wiki/Potato_Ring"
   ],
   "recipes": [
     {
-      "A1": "",
-      "A2": "SHINY_SHARD:1",
-      "A3": "",
-      "B1": "SHINY_SHARD:1",
+      "A1": "ENCHANTED_BAKED_POTATO:8",
+      "A2": "ENCHANTED_BAKED_POTATO:8",
+      "A3": "ENCHANTED_BAKED_POTATO:8",
+      "B1": "ENCHANTED_BAKED_POTATO:8",
       "B2": "POTATO_TALISMAN:1",
-      "B3": "SHINY_SHARD:1",
-      "C1": "",
-      "C2": "SHINY_SHARD:1",
-      "C3": "",
+      "B3": "ENCHANTED_BAKED_POTATO:8",
+      "C1": "ENCHANTED_BAKED_POTATO:8",
+      "C2": "ENCHANTED_BAKED_POTATO:8",
+      "C3": "ENCHANTED_BAKED_POTATO:8",
       "type": "crafting",
       "count": 1,
       "overrideOutputId": "POTATO_RING"


### PR DESCRIPTION
recipe changed from 4 shiny shards and potato talisman to potato talisman surrounded by 64 enchanted baked potato evenly distributed 8 per slot
<img width="422" height="290" alt="image" src="https://github.com/user-attachments/assets/23312bb0-6971-4cf2-979f-9f3cd148905b" />
