### PR TITLE
Fix: Pig Shop & Shiny Pig Loot Table

### DIFF
--- a/items/PIG_SHOP_NPC.json
+++ b/items/PIG_SHOP_NPC.json
@@ -52,6 +52,38 @@
         "ENCHANTED_PORK:32",
         "SHINY_SHARD:64"
       ]
+    },
+    {
+      "type": "npc_shop",
+      "result": "SMALL_PIG_EAR",
+      "cost": [
+        "ENCHANTED_PORK:16",
+        "SHINY_SHARD:32"
+      ]
+    },
+    {
+      "type": "npc_shop",
+      "result": "MEDIUM_PIG_EAR",
+      "cost": [
+        "ENCHANTED_PORK:32",
+        "SHINY_SHARD:32"
+      ]
+    },
+    {
+      "type": "npc_shop",
+      "result": "LARGE_PIG_EAR",
+      "cost": [
+        "ENCHANTED_PORK:64",
+        "SHINY_SHARD:32"
+      ]
+    },
+    {
+      "type": "npc_shop",
+      "result": "GIANT_PIG_EAR",
+      "cost": [
+        "ENCHANTED_GRILLED_PORK",
+        "SHINY_SHARD:32"
+      ]
     }
   ],
   "crafttext": "",

--- a/items/SHINY_ORB.json
+++ b/items/SHINY_ORB.json
@@ -27,7 +27,7 @@
       "panorama": "farming_1",
       "extra": [
         "§7Shiny Pigs show up during",
-        "§7the Year of the Pig event."
+        "§7the §dYear of the Pig §7event."
       ],
       "type": "drops",
       "drops": [
@@ -44,31 +44,31 @@
           "chance": "1.93%"
         },
         {
-          "id": "SKYBLOCK_COINS:10000",
+          "id": "SKYBLOCK_COIN:10000",
           "chance": "19.31%"
         },
         {
-          "id": "SKYBLOCK_COINS:25000",
+          "id": "SKYBLOCK_COIN:25000",
           "chance": "9.66%"
         },
         {
-          "id": "SKYBLOCK_COINS:50000",
+          "id": "SKYBLOCK_COIN:50000",
           "chance": "4.83%"
         },
         {
-          "id": "SKYBLOCK_COINS:100000",
+          "id": "SKYBLOCK_COIN:100000",
           "chance": "2.41%"
         },
         {
-          "id": "SKYBLOCK_COINS:250000",
+          "id": "SKYBLOCK_COIN:250000",
           "chance": "0.97%"
         },
         {
-          "id": "SKYBLOCK_COINS:500000",
+          "id": "SKYBLOCK_COIN:500000",
           "chance": "0.48%"
         },
         {
-          "id": "SKYBLOCK_COINS:1000000",
+          "id": "SKYBLOCK_COIN:1000000",
           "chance": "0.24%"
         },
         {


### PR DESCRIPTION
- Reincluded Pig Ear items into Pig Shop
- Fixed Shiny Pig Loot Table to actually use coins

- Also added colour to descriptor when hovering over the pig