### PR TITLE
fix: remove jerryflower from sacks

### DIFF
--- a/constants/sacks.json
+++ b/constants/sacks.json
@@ -575,7 +575,6 @@
         "GLASSCORN",
         "GLOOMGOURD",
         "GODSEED",
-        "JERRYFLOWER",
         "LONELILY",
         "MAGIC_JELLYBEAN",
         "NOCTILUME",


### PR DESCRIPTION
It can't be put into the mutation sack.