### PR TITLE
feat: update farming tool item modifiers

### DIFF
--- a/constants/enchants.json
+++ b/constants/enchants.json
@@ -74,14 +74,7 @@
     ],
     "AXE": [
       "efficiency",
-      "replenish",
       "silk_touch",
-      "turbo_coco",
-      "turbo_melon",
-      "turbo_pumpkin",
-      "delicate",
-      "sunder",
-      "dedication",
       "absorb",
       "ultimate_first_impression",
       "ultimate_missile"
@@ -191,7 +184,7 @@
       "efficiency",
       "silk_touch"
     ],
-    "HOE": [
+    "FARMING_TOOL": [
       "replenish",
       "harvesting",
       "turbo_wheat",
@@ -204,6 +197,9 @@
       "turbo_rose",
       "turbo_moonflower",
       "turbo_sunflower",
+      "turbo_coco",
+      "turbo_melon",
+      "turbo_pumpkin",
       "cultivating",
       "delicate",
       "dedication"

--- a/constants/reforges.json
+++ b/constants/reforges.json
@@ -777,7 +777,7 @@
   "Green Thumb": {
     "reforgeName": "Green Thumb",
     "nbtModifier": "green_thumb",
-    "itemTypes": "HOE",
+    "itemTypes": "FARMING_TOOL",
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",
@@ -1432,7 +1432,7 @@
   "Peasant's": {
     "reforgeName": "Peasant's",
     "nbtModifier": "peasant",
-    "itemTypes": "HOE",
+    "itemTypes": "FARMING_TOOL",
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",
@@ -1666,7 +1666,7 @@
   },
   "Robust": {
     "reforgeName": "Robust",
-    "itemTypes": "HOE",
+    "itemTypes": "FARMING_TOOL",
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",
@@ -2176,7 +2176,7 @@
   },
   "Zooming": {
     "reforgeName": "Zooming",
-    "itemTypes": "HOE",
+    "itemTypes": "FARMING_TOOL",
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -108,7 +108,7 @@
     "internalName": "BLESSED_FRUIT",
     "reforgeName": "Blessed",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "AXE/HOE",
+    "itemTypes": "FARMING_TOOL",
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",
@@ -1543,7 +1543,7 @@
     "internalName": "GOLDEN_BALL",
     "reforgeName": "Bountiful",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "AXE/HOE",
+    "itemTypes": "FARMING_TOOL",
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",
@@ -1905,7 +1905,7 @@
     "internalName": "LARGE_WALNUT",
     "reforgeName": "Earthy",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "AXE",
+    "itemTypes": "FARMING_TOOL",
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",


### PR DESCRIPTION
Updated enchantments and reforges to make them "farming tool" rather than "axe", "hoe", or "axe/hoe" where appropriate.