### PR TITLE
feat: added missing items from 0.24.4 to bazaar stocks

### DIFF
--- a/constants/bazaarstocks.json
+++ b/constants/bazaarstocks.json
@@ -732,7 +732,7 @@
     "id": "ATTRIBUTE_SHARD_FREEZING_SPREAD;1"
   },
   {
-    "stock": "SHARD_COCOALEECH_SHARD",
+    "stock": "SHARD_COCOALEECH",
     "id": "ATTRIBUTE_SHARD_GROOVY_RADAR;1"
   },
   {
@@ -3762,5 +3762,33 @@
   {
     "stock": "ENCHANTMENT_ULTIMATE_SUNSET_5",
     "id": "ULTIMATE_SUNSET;5"
+  },
+  {
+    "stock": "ENCHANTMENT_TURBO_ROSE_1",
+    "id": "TURBO_ROSE;1"
+  },
+  {
+    "stock": "ENCHANTMENT_TURBO_ROSE_2",
+    "id": "TURBO_ROSE;2"
+  },
+  {
+    "stock": "ENCHANTMENT_TURBO_ROSE_3",
+    "id": "TURBO_ROSE;3"
+  },
+  {
+    "stock": "ENCHANTMENT_TURBO_ROSE_4",
+    "id": "TURBO_ROSE;4"
+  },
+  {
+    "stock": "ENCHANTMENT_TURBO_ROSE_5",
+    "id": "TURBO_ROSE;5"
+  },
+  {
+    "stock": "ENCHANTMENT_SCUBA_1",
+    "id": "SCUBA;1"
+  },
+  {
+    "stock": "ENCHANTMENT_SCUBA_2",
+    "id": "SCUBA;2"
   }
 ]


### PR DESCRIPTION
Some missing enchantments, Cocoaleech shard was renamed in bazaar. Only Moldy Bread is missing, waiting on entry for that.