### PR TITLE
feat: update locust pest drops

### DIFF
--- a/items/PEST_LOCUST_MONSTER.json
+++ b/items/PEST_LOCUST_MONSTER.json
@@ -65,6 +65,11 @@
           "chance": "10%"
         },
         {
+          "id": "LOCUST_LARVA:1",
+          "extra": [],
+          "chance": "2%"
+        },
+        {
           "id": "VINYL_CICADA_SYMPHONY:1",
           "extra": [],
           "chance": "2%"
@@ -75,14 +80,9 @@
           "chance": "0.5%"
         },
         {
-          "id": "SUNDER;6:1",
-          "extra": [],
-          "chance": "0.5%"
-        },
-        {
           "id": "DYE_DUNG:1",
           "extra": [],
-          "chance": "0.0004%"
+          "chance": "0.0002%"
         },
         {
           "id": "ATTRIBUTE_SHARD_PEST_LUCK;1:1",


### PR DESCRIPTION
* remove sunder 6 drop
* add locust larva drop (2% chance)
* fix dung dye drop chance (shows as 1/500,000)