### PR TITLE
ci: minor build workflow fixes

### DIFF
--- a/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
+++ b/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ '247692460' == github.repository_id }}
+    if: ${{ '247692460' == github.repository_id || 'workflow_dispatch' == github.event_name }}
     steps:
     - name: Find HEAD
       id: sha

--- a/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
+++ b/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
@@ -27,7 +27,7 @@ jobs:
         EVENT: ${{ github.event_name }}
         PR: ${{ github.event.pull_request.head.sha }}
         HEAD: ${{ github.sha }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
       with: 
         ref: ${{ steps.sha.outputs.sha }}
     - name: run-checks

--- a/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
+++ b/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
@@ -19,14 +19,14 @@ jobs:
       run: |
         if [ $EVENT == 'pull_request_target' ]
         then
-            echo "::set-output name=sha::$PR"
+            echo "sha=$PR" >> $GITHUB_OUTPUT
         else
-            echo "::set-output name=sha::$HEAD"
+            echo "sha=$HEAD" >> $GITHUB_OUTPUT
         fi
       env:
         EVENT: ${{ github.event_name }}
         PR: ${{ github.event.pull_request.head.sha }}
-        HEAD: ${{ github.context.sha }}
+        HEAD: ${{ github.sha }}
     - uses: actions/checkout@v2
       with: 
         ref: ${{ steps.sha.outputs.sha }}


### PR DESCRIPTION
* Fix `set-output` deprecation warning
* Fix Node 20 deprecation warning for checkout step
* Fix being unable to manually run workflow in forks