### PR TITLE
fix: apply 0.24.3 changes to arachne crystal craft

### DIFF
--- a/items/SHAGGY_NPC.json
+++ b/items/SHAGGY_NPC.json
@@ -19,9 +19,9 @@
     {
       "type": "npc_shop",
       "cost": [
-        "ARACHNE_FRAGMENT:3",
-        "ENCHANTED_SPIDER_EYE:8",
-        "ENCHANTED_STRING:30"
+        "ARACHNE_FRAGMENT:2",
+        "ENCHANTED_SPIDER_EYE:16",
+        "ENCHANTED_STRING:16"
       ],
       "result": "ARACHNE_CRYSTAL"
     }


### PR DESCRIPTION
Noticed that the [0.24.3](https://hypixelskyblock.minecraft.wiki/w/Arachne_Crystal#History) changes haven’t been applied to Arachne.

Applied those changes:

* 3 → 2 Arachne Fragments
* 30 → 16 Enchanted Strings
* 8 → 16 Enchanted Spider Eyes