### PR TITLE
fix(attribute_shards): Flipflopper/Lotusfish/Seashine Bazaar IDs

### DIFF
--- a/constants/attribute_shards.json
+++ b/constants/attribute_shards.json
@@ -2186,7 +2186,7 @@
       "shardId": "E45"
     },
     {
-      "bazaarName": "SHARD_LOTUSFISH",
+      "bazaarName": "SHARD_LOTUS_FISH",
       "displayName": "Lotusfish",
       "rarity": "COMMON",
       "internalName": "ATTRIBUTE_SHARD_LOTUS_TROPHY;1",
@@ -2204,7 +2204,7 @@
       "shardId": "U23"
     },
     {
-      "bazaarName": "SHARD_SEASHINE",
+      "bazaarName": "SHARD_SEA_SHINE",
       "displayName": "Seashine",
       "rarity": "RARE",
       "internalName": "ATTRIBUTE_SHARD_DIAMOND_FROG;1",
@@ -2222,7 +2222,7 @@
       "shardId": "U59"
     },
     {
-      "bazaarName": "SHARD_FLIPFLOPPER",
+      "bazaarName": "SHARD_FLIP_FLOPPER",
       "displayName": "Flipflopper",
       "rarity": "UNCOMMON",
       "internalName": "ATTRIBUTE_SHARD_GOLDEN_FROG;1",


### PR DESCRIPTION
Hypixel just *loves* adding arbitrary underscores.