### PR TITLE
fix: apply patch 0.24.1 to cow minion XII leather requirement

### DIFF
--- a/items/TONY_SHOP_NPC.json
+++ b/items/TONY_SHOP_NPC.json
@@ -88,7 +88,7 @@
       "type": "npc_shop",
       "cost": [
         "SKYBLOCK_PELT:75",
-        "ENCHANTED_LEATHER:1028",
+        "ENCHANTED_LEATHER:1024",
         "COW_GENERATOR_11"
       ],
       "result": "COW_GENERATOR_12"


### PR DESCRIPTION
Applied patch note [0.24.1](https://hypixel.net/threads/hypixel-skyblock-0-24-1-swappable-pet-items-garden-changes-bug-fixes.6052615/) to cow minion in Tony Shop : 
Enchanted leather cost went from 1028 to 1024.

If a double check is needed :
https://wiki.hypixel.net/Cow_Minion
https://hypixelskyblock.minecraft.wiki/w/Cow_Minion