### PR TITLE
fix(bestiary): rename Gravel Skeleton to Flint Skeleton

### DIFF
--- a/constants/bestiary.json
+++ b/constants/bestiary.json
@@ -587,7 +587,7 @@
         "bracket": 2
       },
       {
-        "name": "§aGravel Skeleton",
+        "name": "§aFlint Skeleton",
         "skullOwner": "53924f1a-87e6-4709-8e53-f1c7d13dc239",
         "texture": "ewogICJ0aW1lc3RhbXAiIDogMTY1NTYzMTgzNjcwNCwKICAicHJvZmlsZUlkIiA6ICI1MzkyNGYxYTg3ZTY0NzA5OGU1M2YxYzdkMTNkYzIzOSIsCiAgInByb2ZpbGVOYW1lIiA6ICJUaHJvd3BvIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzg4ZWI2OGE0ZDM4ZTlmNDQ2YjhlOTkyNzVmMTYwMzAyZjM2NmVmMTAyMTZhYmY5NDg0ODdlNTgyNTEyYmQwZjMiCiAgICB9CiAgfQp9=",
         "cap": 4000,


### PR DESCRIPTION
The mob was renamed but the bestiary entry wasn't.