### PR TITLE
Rework resource pack file

### DIFF
--- a/constants/resource_pack.json
+++ b/constants/resource_pack.json
@@ -1,13 +1,8 @@
 {
-	"latest_resource_pack": {
-		"88": {
-			"url": "https://resourcepacks2.hypixel.net/SkyBlockResourcePack/52683b03-a531-41e5-8b65-367464875e09/88.zip"
-		},
-		"84": {
-			"url": "https://resourcepacks2.hypixel.net/SkyBlockResourcePack/52683b03-a531-41e5-8b65-367464875e09/84.zip"
-		},
-		"75": {
-			"url": "https://resourcepacks2.hypixel.net/SkyBlockResourcePack/52683b03-a531-41e5-8b65-367464875e09/75.zip"
+	"item_models": {
+		"removed": [
+		],
+		"renamed": {
 		}
 	}
 }


### PR DESCRIPTION
The new `item_models` section has to do with the `minecraft:item_model` components that are applied to items. The `removed` array should contain the ids of item models that have been removed from the SkyBlock Resource Pack, and the `renamed` map should point old models to their new ones.

This is useful for applications which may need to "fix up" item model data given its likely some of them will be moved around in the SkyBlock pack (it has a lot of inconsistencies with where they are placed).

This is likely best maintained with a script from the Hypixel API which should have most models, or perhaps a script that checks against this repo. The format of this is intended to be the exact same as Minecraft's deprecated.json for translation keys.