### PR TITLE
Correct spelling of 'Specter' to 'Spectre'

### DIFF
--- a/constants/attribute_shards.json
+++ b/constants/attribute_shards.json
@@ -297,7 +297,7 @@
     },
     {
       "bazaarName": "SHARD_WITHER_SPECTER",
-      "displayName": "Wither Specter",
+      "displayName": "Wither Spectre",
       "rarity": "RARE",
       "internalName": "ATTRIBUTE_SHARD_BREEZE;1",
       "abilityName": "Breeze",


### PR DESCRIPTION
Ingame the actual name is "spectre" 
<img width="448" height="437" alt="image" src="https://github.com/user-attachments/assets/50148785-688b-4bba-a621-842cac39e20f" /> 
and the item/bz id is "specter" as seen on https://api.hypixel.net/v2/skyblock/bazaar