### PR TITLE
Add wiki link to Frog the Fish (reversed)

### DIFF
--- a/items/GORF_THE_FISH.json
+++ b/items/GORF_THE_FISH.json
@@ -13,5 +13,7 @@
   "crafttext": "",
   "modver": "Firmament 44.2.0-dev+mc1.21.11+ga2a6cfec",
   "infoType": "",
-  "info": []
+  "info": [
+    "https://hypixelskyblock.minecraft.wiki/w/HsiF_ehT_gorF"
+  ]
 }

--- a/items/GORF_THE_FISH.json
+++ b/items/GORF_THE_FISH.json
@@ -12,7 +12,7 @@
   "clickcommand": "",
   "crafttext": "",
   "modver": "Firmament 44.2.0-dev+mc1.21.11+ga2a6cfec",
-  "infoType": "",
+  "infoType": "WIKI_URL",
   "info": [
     "https://hypixelskyblock.minecraft.wiki/w/HsiF_ehT_gorF"
   ]


### PR DESCRIPTION
I found this didn't have one in game when I tried to use it in the Wiki Lookup so here it is. I think I did this correctly.