### PR TITLE
Add Mushroom Collection item

### DIFF
--- a/items/MUSHROOM_COLLECTION.json
+++ b/items/MUSHROOM_COLLECTION.json
@@ -1,0 +1,18 @@
+{
+  "itemid": "minecraft:red_mushroom",
+  "displayname": "§fMushroom",
+  "nbttag": "{ExtraAttributes:{id:\"MUSHROOM_COLLECTION\"},HideFlags:254,ItemModel:\"minecraft:red_mushroom\",display:{Lore:[0:\"§fCOMMON\"],Name:\"§fMushroom\"}}",
+  "damage": 0,
+  "lore": [
+    "§fCOMMON"
+  ],
+  "internalname": "MUSHROOM_COLLECTION",
+  "clickcommand": "",
+  "crafttext": "",
+  "modver": "Firmament nogitversion+mc26.2",
+  "infoType": "WIKI_URL",
+  "info": [
+    "https://hypixelskyblock.minecraft.wiki/w/Mushroom",
+    "https://wiki.hypixel.net/Mushroom"
+  ]
+}

--- a/itemsOverlay/4903/MUSHROOM_COLLECTION.snbt
+++ b/itemsOverlay/4903/MUSHROOM_COLLECTION.snbt
@@ -1,0 +1,32 @@
+{
+	components: {
+		"minecraft:custom_data": {
+			id: "MUSHROOM_COLLECTION"
+		},
+		"minecraft:tooltip_display": {
+			hidden_components: [
+				"minecraft:painting/variant",
+				"minecraft:fireworks",
+				"minecraft:attribute_modifiers",
+				"minecraft:enchantments",
+				"minecraft:stored_enchantments",
+				"minecraft:trim",
+				"minecraft:charged_projectiles",
+				"minecraft:jukebox_playable",
+				"minecraft:map_id",
+				"minecraft:unbreakable",
+				"minecraft:written_book_content",
+				"minecraft:banner_patterns",
+				"minecraft:potion_contents",
+				"minecraft:dyed_color"
+			]
+		},
+		"minecraft:tooltip_style": "hypixel_skyblock:common"
+	},
+	count: 1,
+	id: "minecraft:red_mushroom",
+	source: {
+		dataVersion: 4903,
+		modVersion: "Firmament nogitversion+mc26.2"
+	}
+}


### PR DESCRIPTION
This adds the mushroom collection icon from the SkyBlock menus, it should be useful for the Skyblocker Profile Viewer Collections page. I made it similar to the current GEMSTONE_COLLECTION item in the repo in terms of the name, lore, and tooltip style (gemstone collection icon is fine jasper and thus used rare so I put this at common).