### PR TITLE
ci: fix repo workflow

### DIFF
--- a/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
+++ b/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
@@ -27,9 +27,10 @@ jobs:
         EVENT: ${{ github.event_name }}
         PR: ${{ github.event.pull_request.head.sha }}
         HEAD: ${{ github.sha }}
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with: 
         ref: ${{ steps.sha.outputs.sha }}
+        allow-unsafe-pr-checkout: true
     - name: run-checks
       uses: NotEnoughUpdates/NotEnoughUpdates-REPO-Workflow@main
       with: 

--- a/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
+++ b/.github/workflows/NotEnoughUpdates-REPO-Workflow.yml
@@ -2,8 +2,6 @@ name: NotEnoughUpdates REPO Workflow
 
 # Controls when the action will run. 
 on:
-  pull_request_target:
-    branches: [ master ]
   push:
     branches: [ master ]
   workflow_dispatch:
@@ -30,7 +28,6 @@ jobs:
     - uses: actions/checkout@v7
       with: 
         ref: ${{ steps.sha.outputs.sha }}
-        allow-unsafe-pr-checkout: true
     - name: run-checks
       uses: NotEnoughUpdates/NotEnoughUpdates-REPO-Workflow@main
       with: 


### PR DESCRIPTION
😭 can we replace this old workflow

(fails since it is using actions from the master branch) 