### PR TITLE
Fix outdated panorama in MUTANT_TARANTULA_MINIBOSS.json

### DIFF
--- a/items/MUTANT_TARANTULA_MINIBOSS.json
+++ b/items/MUTANT_TARANTULA_MINIBOSS.json
@@ -24,7 +24,7 @@
       "render": "Spider",
       "level": 380,
       "type": "drops",
-      "panorama": "combat_2",
+      "panorama": "crimson_isle",
       "drops": [
         {
           "id": "TARANTULA_WEB:5",


### PR DESCRIPTION
Panorama references still the blazing fortress id instead of crimson isle.